### PR TITLE
fix: dead link in migration comment

### DIFF
--- a/boilerplate/stubs/migration.php
+++ b/boilerplate/stubs/migration.php
@@ -5,7 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 // HINT: you might want to use a `Flarum\Database\Migration` helper method for simplicity!
-// See https://docs.flarum.org/extend/data.html#migrations to learn more about migrations.
+// See https://docs.flarum.org/extend/models.html#migrations to learn more about migrations.
 return [
     'up' => function (Builder $schema) {
         // up migration


### PR DESCRIPTION
Fixes a dead docs link in the Migration stub's comment.