### PR TITLE
fix: fully use yarn in extension CI workflows

### DIFF
--- a/boilerplate/skeleton/extension/.github/workflows/js.yml
+++ b/boilerplate/skeleton/extension/.github/workflows/js.yml
@@ -18,15 +18,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: js/package-lock.json
+          cache: "yarn"
+          cache-dependency-path: js/yarn.lock
 
       - name: Install JS dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
         working-directory: ./js
 
       - name: Check JS formatting
-        run: npm run format-check
+        run: yarn run format-check
         working-directory: ./js
 
   build-prod:
@@ -46,11 +46,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: js/package-lock.json
+          cache: "yarn"
+          cache-dependency-path: js/yarn.lock
 
-      # Our action will install npm, cd into `./js`, run `npm run build` and
-      # `npm run build-typings`, then commit and upload any changes
+      # Our action will install node, npm and yarn, cd into `./js`, run `yarn run build` (and
+      # `yarn run build-typings` if desired), then commit and upload any changes
       - name: Build production JS
         uses: flarum/action-build@2
         with:
@@ -76,11 +76,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
-          cache-dependency-path: js/package-lock.json
+          cache: "yarn"
+          cache-dependency-path: js/yarn.lock
 
-      # Our action will install npm, cd into `./js`, run `npm run build` and
-      # `npm run build-typings`, then commit and upload any changes
+      # Our action will install node, npm and yarn, cd into `./js`, run `yarn run build` (and
+      # `yarn run build-typings` if desired). It will NOT commit and upload.
       - name: Build production JS
         uses: flarum/action-build@2
         with:


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Fully switch to Yarn for our entire CI workflow.

This resolves some issues surrounding module caching and `npm ci` when no npm lockfile exists.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
None

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.
