### PR TITLE
Disable escaping of license content

### DIFF
--- a/boilerplate/skeleton/extension/LICENSE.md
+++ b/boilerplate/skeleton/extension/LICENSE.md
@@ -1,1 +1,1 @@
-<%= params.licenseText %>
+<%- params.licenseText %>


### PR DESCRIPTION
`<%=` encodes `"` into `&#34;`, which is not necessary for markdown. And while it works and markdown is rendered correctly, it breaks license detection on GitHub. For example https://github.com/blomstra/flarum-ext-user-filter has unknown license:

![cfebee99](https://user-images.githubusercontent.com/5972388/154511774-f60e295f-1e06-4ab3-8af4-4e93439da71c.png)

