### PR TITLE
fix: typings build fails when `@types` does not exist

### DIFF
--- a/boilerplate/skeleton/extension/js/package.json
+++ b/boilerplate/skeleton/extension/js/package.json
@@ -20,8 +20,9 @@
     "analyze": "cross-env ANALYZER=true <%= params.jsPackageManager %> run build",
     "format": "prettier --write src",
     "format-check": "prettier --check src",
+    "typings:copy": "([ -e src/@types ] && cp -r src/@types dist-typings/@types) || true",
     "clean-typings": "npx rimraf dist-typings && mkdir dist-typings",
-    "build-typings": "<%= params.jsPackageManager %> run clean-typings && [ -e src/@types ] && cp -r src/@types dist-typings/@types && tsc && <%= params.jsPackageManager %> run post-build-typings",
+    "build-typings": "<%= params.jsPackageManager %> run clean-typings && <%= params.jsPackageManager %> run typings:copy && tsc && <%= params.jsPackageManager %> run post-build-typings",
     "post-build-typings": "find dist-typings -type f -name '*.d.ts' -print0 | xargs -0 sed -i 's,../src/@types,@types,g'",
     "check-typings": "tsc --noEmit --emitDeclarationOnly false",
     "check-typings-coverage": "typescript-coverage-report"


### PR DESCRIPTION


<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This folder is not mandatory when using typings in a Flarum extension, so we should allow typings to be built without it.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?
