### PR TITLE
Yarn requires version to install dependencies

### DIFF
--- a/boilerplate/skeleton/extension/js/package.json
+++ b/boilerplate/skeleton/extension/js/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@<%= params.packageName %>",
   "private": true,
+  "version": "0.0.0",
   "prettier": "@flarum/prettier-config",
   "dependencies": {
   },


### PR DESCRIPTION
**Fixes #28**

**Changes proposed in this pull request:**
Yarn requires version property to install dependencies