### PR TITLE
Fix URL to the i18n documentation

### DIFF
--- a/boilerplate/skeleton/extension/locale/en.yml
+++ b/boilerplate/skeleton/extension/locale/en.yml
@@ -1,6 +1,6 @@
 <%= params.extensionId %>:
   # For more details on the format
-  # Checkout https://docs.flarum.org/extend/i18n.html#appendix-a-standard-key-format
+  # Checkout https://docs.flarum.org/extend/i18n/#appendix-a-standard-key-format
   admin:
     my_cool_key: My Cool Key
 


### PR DESCRIPTION
The old page responds with an error: "No input file specified."

**Changes proposed in this pull request:**
The URL to the i18n appendix A standard key format documentation was fixed. The old URL responded with an error "No input specified.", because the URL or documentation format had likely changed.

**Reviewers should focus on:**
Is the old URL supposed to still work? It's probably an issue on it's own (`.html` URLs should be redirected to new ones in docs).

**Screenshot**
![image](https://user-images.githubusercontent.com/39010496/167158405-64038796-1722-46fe-b13b-f1b635d745bb.png)


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.