### PR TITLE
use `https` for Flarum home page

### DIFF
--- a/boilerplate/skeleton/extension/README.md
+++ b/boilerplate/skeleton/extension/README.md
@@ -2,7 +2,7 @@
 
 ![License](https://img.shields.io/badge/license-<%= params.licenseType %>-blue.svg) [![Latest Stable Version](https://img.shields.io/packagist/v/<%= params.packageName %>.svg)](https://packagist.org/packages/<%= params.packageName %>) [![Total Downloads](https://img.shields.io/packagist/dt/<%= params.packageName %>.svg)](https://packagist.org/packages/<%= params.packageName %>)
 
-A [Flarum](http://flarum.org) extension. <%= params.packageDescription %>
+A [Flarum](https://flarum.org) extension. <%= params.packageDescription %>
 
 ## Installation
 


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
