### PR TITLE
fix: correct backslash escaping in PHP namespaces

### DIFF
--- a/src/boilersmith/scaffolding/module.ts
+++ b/src/boilersmith/scaffolding/module.ts
@@ -225,11 +225,6 @@ export async function applyModule<MN extends string, TN extends string>(
     string
   >;
 
-  // This is necessary because one layer of escaped backslashes is lost on template population.
-  tplData.params = Object.fromEntries(Object.entries(paramVals).map(([k, v]) => [k, typeof v === 'string' ? v.replace('\\', '\\\\') : v])) as Record<
-    TN,
-    unknown
-  >;
 
   for (const file of module.filesToReplace) {
     const path = typeof file === 'string' ? file : file.path;
@@ -270,8 +265,15 @@ export async function applyModule<MN extends string, TN extends string>(
   }
 
   const jsonPaths = cloneAndFill(module.jsonToAugment, tplDataFlat);
+
+  // This is necessary because one layer of escaped backslashes is lost on template population.
+  const clonedTplData = { ...tplData };
+  clonedTplData.params = Object.fromEntries(
+    Object.entries(paramVals).map(([k, v]) => [k, typeof v === 'string' ? v.replace('\\', '\\\\') : v])
+  ) as Record<TN, unknown>;
+
   for (const jsonPath of Object.keys(jsonPaths)) {
-    const scaffoldContents = readTpl(resolve(scaffoldDir, jsonPath), tplData);
+    const scaffoldContents = readTpl(resolve(scaffoldDir, jsonPath), clonedTplData);
     const scaffoldContentsJson = JSON.parse(scaffoldContents);
 
     const excludeKeys = cloneAndFill(excludeScaffolding.configKeys[jsonPath] ?? [], tplDataFlat);

--- a/src/steps/gen-ext-scaffolder.ts
+++ b/src/steps/gen-ext-scaffolder.ts
@@ -11,6 +11,7 @@ import { resolve } from 'path';
 import simpleGit from 'simple-git';
 import spdxLicenseListSimple from 'spdx-license-list/simple';
 import { getComposerJson } from '../utils/composer';
+import s from 'string';
 
 function assertUnreachable(_x: never): never {
   throw new Error("Didn't expect to get here");
@@ -75,6 +76,13 @@ function paramNamesToDef(name: ExtensionParams): TemplateParam<string, Extension
           name,
           type: 'text',
           message: `Package namespace ${chalk.dim('(Vendor\\ExtensionName)')}`,
+          initial: (_prev, values) =>
+            (values as unknown as Map<string, string>)
+              .get('packageName')!
+              .replace('/flarum-', '/')
+              .split('/')
+              .map((b: string) => s(b).camelize().capitalize().toString())
+              .join('\\'),
           validate: (s) => /^([\dA-Za-z]+)\\([\dA-Za-z]+)$/.test(s.trim()) || 'Invalid namespace format',
           format: (str: string) =>
             str &&
@@ -86,7 +94,7 @@ function paramNamesToDef(name: ExtensionParams): TemplateParam<string, Extension
         getCurrVal: async (fs: Store, paths: Paths) => {
           const json = getComposerJson(fs, paths);
           const namespace = (Object.keys(json?.autoload?.['psr-4'] ?? {})?.[0] ?? '')?.slice(0, -1);
-          return namespace || '';
+          return (namespace || '').replace('\\\\', '\\');
         },
       };
 
@@ -124,6 +132,12 @@ function paramNamesToDef(name: ExtensionParams): TemplateParam<string, Extension
           type: 'text',
           message: 'Extension name',
           validate: (str) => Boolean(str.trim()) || 'The extension name is required',
+          initial: (_prev, values) =>
+            s((values as unknown as Map<string, string>).get('packageName')!.split('/')[1])
+              .replaceAll('flarum-', '')
+              .humanize()
+              .capitalize()
+              .toString(),
           format: (str) =>
             str
               .split(' ')


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Resolves an issue where `extend.php` was incorrectly generated with double backslashes (e.g., `Vendor\\Extension`). The scaffolding engine now mirrors `3.x` behavior: escaping backslashes only for JSON files and keeping them single for PHP files.

The CLI will now also correctly normalize and clean up existing double backslashes when updating an extension's namespace.


**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
