### PR TITLE
fix: forced monorepo splits fail during cleanup

### DIFF
--- a/src/commands/monorepo/split.ts
+++ b/src/commands/monorepo/split.ts
@@ -17,6 +17,6 @@ export default class Split extends BaseCommand {
   protected requireExistingExtension = false;
 
   protected steps(stepManager: StepManager<FlarumProviders>): StepManager<FlarumProviders> {
-    return stepManager.step(new MonorepoSplit(this.flags.force));
+    return stepManager.step(new MonorepoSplit(this.flags.force, this.flags['no-interaction']));
   }
 }

--- a/src/steps/monorepo/split.ts
+++ b/src/steps/monorepo/split.ts
@@ -48,8 +48,13 @@ async function splitAndPush(cwd: string, splitExecPath: string, splitPath: strin
 
 async function cleanupBranchAndRemote(cwd: string, name: string) {
   await simpleGit(cwd).removeRemote(name);
-  const tmpBranch = `${name}-tmp`;
-  execSync(`git branch -D ${tmpBranch}`, { cwd });
+  try {
+    const tmpBranch = `${name}-tmp`;
+    execSync(`git branch -D ${tmpBranch}`, { cwd, stdio: 'ignore' });
+  } catch {
+    // A forced split pushes the split sha straight to the remote, so it never
+    // creates the temp branch this deletes.
+  }
 }
 
 export class MonorepoSplit implements Step<FlarumProviders> {
@@ -57,9 +62,11 @@ export class MonorepoSplit implements Step<FlarumProviders> {
   composable = false;
   exposes = [];
   force?: boolean;
+  noInteraction?: boolean;
 
-  constructor(force: boolean) {
+  constructor(force: boolean, noInteraction = false) {
     this.force = force;
+    this.noInteraction = noInteraction;
   }
 
   async run(fs: Store, paths: Paths, io: IO, _providers: FlarumProviders): Promise<Store> {
@@ -71,7 +78,11 @@ export class MonorepoSplit implements Step<FlarumProviders> {
       return fs;
     }
 
-    if (this.force && !(await io.getParam({ type: 'confirm', name: 'confirm', initial: false, message: 'Are you sure you want to force split?' }))) {
+    if (
+      this.force &&
+      !this.noInteraction &&
+      !(await io.getParam({ type: 'confirm', name: 'confirm', initial: false, message: 'Are you sure you want to force split?' }))
+    ) {
       io.error('Decided not to force push', true);
       return fs;
     }


### PR DESCRIPTION
Two bugs in `monorepo:split --force`, both found by using it regularly on the Flarum monorepo.

## Cleanup deletes a branch that a forced split never creates

`splitAndPush()` only creates the `<remote>-tmp` branch on the **non**-forced path:

```ts
if (force) {
  execSync(`git push --force ${pushArgs}`, { cwd });   // pushes the sha directly
} else {
  execSync(`git switch -c ${tmpBranch} ${sha1}`, { cwd });
  …
}
```

but `cleanupBranchAndRemote()` ran `git branch -D <remote>-tmp` unconditionally. So every forced split threw once all the pushes had already succeeded — the work was done, the command still ended in an error.

## `--force` ignored `--no-interaction`

The force confirmation is a `confirm` param with `initial: false`. In non-interactive mode `PromptsIO::getParam()` returns the initial value rather than prompting, so the answer was always "no" and `monorepo:split --force --no-interaction` reliably printed *"Decided not to force push"* and did nothing.

That's precisely the flag combination a script or CI job would use, and it silently no-oped. The confirmation is now skipped when the operator has already asked not to be prompted — `--no-interaction` means "don't ask me", so a forced split proceeds.

Worth being deliberate about: this makes `--force --no-interaction` genuinely force-push to every split repo without confirmation. That is the intent of the flag pair, and the guard remains for interactive use.

## Verification

`yarn test` — 22 suites, 176 tests, Prettier clean. Both paths exercised by hand against the Flarum monorepo on Apple silicon over an extended period.