### PR TITLE
feat: show test warning details in generated PHPUnit configs

### DIFF
--- a/boilerplate/skeleton/extension/tests/phpunit.integration.xml
+++ b/boilerplate/skeleton/extension/tests/phpunit.integration.xml
@@ -6,6 +6,7 @@
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
     colors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     processIsolation="true"
     stopOnFailure="false"
 >

--- a/boilerplate/skeleton/extension/tests/phpunit.unit.xml
+++ b/boilerplate/skeleton/extension/tests/phpunit.unit.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
     cacheDirectory=".phpunit.cache"
     backupStaticProperties="false"
     colors="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
     processIsolation="false"
     stopOnFailure="false"
 >


### PR DESCRIPTION
## Why

Flarum's integration `TestCase` now inspects each request for N+1 query patterns ([flarum/framework#4871](https://github.com/flarum/framework/pull/4871)). A query run once per record fails the test; one repeated for the same few values raises a **warning** instead, since it doesn't grow with the forum.

PHPUnit only prints what a warning *said* when `displayDetailsOnTestsThatTriggerWarnings` is enabled. Without it a run ends with:

```
OK, but there were issues!
Tests: 82, Assertions: 344, Warnings: 11.
```

— visible, but with no indication of which queries or where. Both generated configs now set the flag, so extension authors get the finding itself. Since `backendTesting` is `updatable`, existing extensions pick it up by re-running `flarum-cli infra backendTesting`, not just newly generated ones.

## Also: the unit config's schema reference

`phpunit.unit.xml` pointed at `https://schema.phpunit.de/10.5/phpunit.xsd` while `phpunit.integration.xml` used `../vendor/phpunit/phpunit/phpunit.xsd`. Flarum 2.x requires PHPUnit `^12.5`, so the remote reference was both a version behind what gets installed and dependent on the network to validate. It now matches the integration config — which is also what extensions in the wild use (I checked several standalone 2.x extensions rather than core, whose deeper path in the monorepo isn't representative).

## Verification

- Both configs validate against a real PHPUnit 12.5 `phpunit.xsd` via `xmllint --schema`.
- `yarn test` — 22 suites, 176 tests, Prettier clean.