### PR TITLE
fix: refresh 2.x scaffolding after the beta and RC releases

### DIFF
--- a/boilerplate/skeleton/extension/js/package.json
+++ b/boilerplate/skeleton/extension/js/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@flarum/jest-config": "^1.0.1",
+    "@flarum/jest-config": "^2.0.0",
     "@flarum/prettier-config": "^1.0.0",
     "flarum-tsconfig": "^2.0.0",
     "flarum-webpack-config": "^3.0.0",

--- a/boilerplate/skeleton/extension/phpstan.neon
+++ b/boilerplate/skeleton/extension/phpstan.neon
@@ -8,5 +8,4 @@ parameters:
     - src
   excludePaths:
     - *.blade.php
-  checkMissingIterableValueType: false
   databaseMigrationsPath: ['migrations']

--- a/src/steps/upgrade/twopointoh/dependencies.ts
+++ b/src/steps/upgrade/twopointoh/dependencies.ts
@@ -58,7 +58,7 @@ export default class Dependencies extends BaseUpgradeStep {
         });
 
         if (key === 'flarum/core') {
-          composer.require[key] = '^2.0.0-beta';
+          composer.require[key] = '^2.0.0';
         } else if (key.startsWith('flarum/') && value !== '*') {
           composer.require[key] = '*';
         }
@@ -74,15 +74,21 @@ export default class Dependencies extends BaseUpgradeStep {
         });
 
         if (['flarum/core', 'flarum/testing', 'flarum/phpstan'].includes(key)) {
-          composer['require-dev'][key] = '^2.0.0-beta';
+          composer['require-dev'][key] = '^2.0.0';
         } else if (key.startsWith('flarum/') && (value as string).startsWith('^1')) {
           composer['require-dev'][key] = '*';
         }
       }
 
       if (composer.require.php) {
-        composer.require.php = '^8.2';
+        composer.require.php = '^8.3';
       }
+
+      // 2.0 constraints resolve to prereleases while the line is in RC, so the
+      // extension has to accept them — with stable preferred wherever one
+      // exists, so only Flarum itself comes from the beta channel.
+      composer['minimum-stability'] = 'beta';
+      composer['prefer-stable'] = true;
 
       if (composer.require['fof/extend']) {
         composer.require['fof/extend'] = '^2.0.0';


### PR DESCRIPTION
The last release was v3.0.11 in April 2025, before the remaining betas and every RC. Four things have drifted since; the first one stops a generated extension working at all.

## Generated extensions can't run static analysis

`boilerplate/skeleton/extension/phpstan.neon` sets `checkMissingIterableValueType: false`, a parameter **removed in PHPStan 2**. `flarum/phpstan ^2.0` installs PHPStan `^2.1`, so `composer analyse:phpstan` on a freshly scaffolded extension fails before analysing anything:

```
Invalid configuration:
Unexpected item 'parameters › checkMissingIterableValueType'.
```

Verified by running PHPStan 2 against that exact config in a real 2.x extension — and verified fixed the same way (13 files analysed, no configuration error).

## Skeleton asks for the wrong jest config

`@flarum/jest-config: ^1.0.1`, where core 2.x uses `^2.0.0`. v1 also depends on `flarum-webpack-config ^2.0.1`, which contradicts the `^3.0.0` the skeleton specifies in the same file.

Worth noting: the **upgrade** command already sets `^2.0.0`, so an extension upgraded to 2.x got this right while a newly created one did not.

## The upgrade command still writes beta constraints

`flarum/core`, `flarum/testing` and `flarum/phpstan` were pinned to `^2.0.0-beta` — correct when written, but it now leaves every upgraded extension asking for a beta of a line that has reached RC.

These become `^2.0.0`. Since 2.0 is still prerelease, the command now also sets `minimum-stability: "beta"` and `prefer-stable: true` on the extension's `composer.json`, so the constraint resolves while preferring stable releases for everything that has one.

## PHP floor

The upgrade command rewrote `require.php` to `^8.2`. Core 2.x requires `^8.3`.

## Verification

`yarn test` — 22 suites, 176 tests, Prettier clean; `tsc --noEmit` clean. The PHPStan change was checked against a real extension's installed PHPStan 2 rather than by reading.

The skeleton's `minimum-stability` stays `dev` — deliberate, and unchanged here.